### PR TITLE
Throttle list scroll updates with requestAnimationFrame

### DIFF
--- a/ElementaroInfo/ui/app.js
+++ b/ElementaroInfo/ui/app.js
@@ -305,7 +305,14 @@
     }
 
     const listWrap=$('#listWrap'), tbody=$('#tbody'), spacer=$('#spacer');
-    listWrap.addEventListener('scroll', drawWindow);
+    let scrollRAF=null;
+    listWrap.addEventListener('scroll', ()=>{
+      if(scrollRAF) return;
+      scrollRAF = requestAnimationFrame(()=>{
+        scrollRAF=null;
+        drawWindow();
+      });
+    });
 
     function render(){
       refreshChips();


### PR DESCRIPTION
## Summary
- Throttle list `scroll` events using `requestAnimationFrame` to ensure `drawWindow` runs at most once per frame.

## Testing
- `node --check ElementaroInfo/ui/app.js` *(fails: invalid or unexpected token)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990e1328f4832cb1d1b075ecf2e0e5