### PR TITLE
Add accessible tab buttons with keyboard support

### DIFF
--- a/ElementaroInfo/ui/app.js
+++ b/ElementaroInfo/ui/app.js
@@ -186,17 +186,36 @@
     $('#decimals').onchange = (e)=>{ decimals=parseInt(e.target.value||2,10); localStorage.setItem('EA_DECIMALS', String(decimals)); render(); };
     $('#countMode').onchange = render;
 
-    document.querySelectorAll('.tab').forEach(t=>{
-      t.onclick=()=>{
-        document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
-        t.classList.add('active');
-        const tab=t.dataset.tab;
-        $('#listView').style.display = tab==='list' ? '' : 'none';
-        $('#cardsView').style.display = tab==='cards'? '' : 'none';
-        $('#catalogView').style.display = tab==='catalog'? '' : 'none';
-        if(tab==='catalog') drawCatalog();
-      };
+    const tabs = Array.from(document.querySelectorAll('.ea-tabs .tab'));
+    function activateTab(t){
+      tabs.forEach(x=>{
+        const active = x===t;
+        x.classList.toggle('active', active);
+        x.setAttribute('aria-selected', active? 'true':'false');
+        x.setAttribute('tabindex', active? '0':'-1');
+        const view=document.getElementById(x.getAttribute('aria-controls'));
+        if(view) view.style.display = active? '' : 'none';
+      });
+      if(t.dataset.tab==='catalog') drawCatalog();
+    }
+    tabs.forEach(t=>{
+      t.addEventListener('click', ()=>activateTab(t));
+      t.addEventListener('keydown', e=>{
+        if(e.key==='ArrowRight' || e.key==='ArrowLeft'){
+          e.preventDefault();
+          const dir = e.key==='ArrowRight'?1:-1;
+          let idx = tabs.indexOf(t) + dir;
+          if(idx<0) idx = tabs.length-1;
+          if(idx>=tabs.length) idx = 0;
+          tabs[idx].focus();
+          activateTab(tabs[idx]);
+        } else if(e.key==='Enter'){
+          e.preventDefault();
+          activateTab(t);
+        }
+      });
     });
+    activateTab(document.querySelector('.ea-tabs .tab.active') || tabs[0]);
 
     (function init(){
       $('#attrKeys').value = loadLS('EA_ATTRS', 'sku,variant,unit,price_eur,owner,supplier,article_number,description');

--- a/ElementaroInfo/ui/index.html
+++ b/ElementaroInfo/ui/index.html
@@ -67,17 +67,17 @@
     </aside>
 
     <main class="ea-main">
-      <div class="ea-tabs">
-        <div class="tab active" data-tab="list">Liste</div>
-        <div class="tab" data-tab="cards">Karten/Library</div>
-        <div class="tab" data-tab="catalog">Katalog (alle Definitionen)</div>
+      <div class="ea-tabs" role="tablist">
+        <button class="tab active" data-tab="list" id="tab-list" role="tab" aria-controls="listView" aria-selected="true" tabindex="0">Liste</button>
+        <button class="tab" data-tab="cards" id="tab-cards" role="tab" aria-controls="cardsView" aria-selected="false" tabindex="-1">Karten/Library</button>
+        <button class="tab" data-tab="catalog" id="tab-catalog" role="tab" aria-controls="catalogView" aria-selected="false" tabindex="-1">Katalog (alle Definitionen)</button>
       </div>
 
       <div class="ea-view">
         <div id="loading" class="ea-loading"><div class="box">Bitte warten…</div></div>
 
         <!-- LIST -->
-        <div id="listView" class="view">
+        <div id="listView" class="view" role="tabpanel" aria-labelledby="tab-list">
           <div id="listWrap">
             <table>
               <thead><tr id="thead"></tr></thead>
@@ -88,7 +88,7 @@
         </div>
 
         <!-- CARDS + INSPECTOR -->
-        <div id="cardsView" class="view" style="display:none">
+        <div id="cardsView" class="view" style="display:none" role="tabpanel" aria-labelledby="tab-cards">
           <div id="cards"></div>
           <aside id="inspector">
             <h3>Inspector</h3>
@@ -98,7 +98,7 @@
         </div>
 
         <!-- CATALOG: alle Definitionen -->
-        <div id="catalogView" class="view" style="display:none">
+        <div id="catalogView" class="view" style="display:none" role="tabpanel" aria-labelledby="tab-catalog">
           <div id="catalog"></div>
         </div>
       </div>

--- a/ElementaroInfo/ui/styles.css
+++ b/ElementaroInfo/ui/styles.css
@@ -14,8 +14,8 @@ button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 .section{padding:12px;border-bottom:1px solid var(--border)} .sec-title{font-weight:600;margin-bottom:6px}
 .ea-main{flex:1;display:flex;flex-direction:column}
 .ea-tabs{display:flex;border-bottom:1px solid var(--border)}
-.tab{padding:8px 12px;cursor:pointer;border-bottom:2px solid transparent}
-.tab.active{border-color:var(--accent);color:var(--accent);font-weight:600}
+.ea-tabs .tab{padding:8px 12px;cursor:pointer;border:none;background:none;border-radius:0;border-bottom:2px solid transparent}
+.ea-tabs .tab.active{border-color:var(--accent);color:var(--accent);font-weight:600}
 .ea-view{flex:1;position:relative}
 .view{position:absolute;inset:0}
 #loading{position:absolute;inset:0;display:none;align-items:center;justify-content:center;background:rgba(255,255,255,.7);z-index:10}


### PR DESCRIPTION
## Summary
- Replace tab divs with accessible buttons and add ARIA attributes
- Enable keyboard navigation for tabs with arrow keys and Enter
- Style tab buttons to match existing layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68990e12fce4832c8daa48dad9f891ee