### PR TITLE
Fix instance attribute precedence in ElementaroInfo scan

### DIFF
--- a/ElementaroInfo/main.rb
+++ b/ElementaroInfo/main.rb
@@ -390,8 +390,8 @@
           path      = (chain + [display]).join(' / ')
           parent    = chain.last || ''
 
-          attrs = read_attrs(e)
-          attrs.merge!(read_attrs(defn)) if defn
+          attrs = defn ? read_attrs(defn) : {}
+          attrs.merge!(read_attrs(e))
           picked = pick(attrs, (opts['attr_keys']||[]))
           price  = (picked['price_eur']||0).to_f
 


### PR DESCRIPTION
## Summary
- ensure `scan_iterative` reads definition attributes first and merges instance attributes afterward so instances override defaults

## Testing
- `ruby -c ElementaroInfo/main.rb` *(fails: syntax errors in ElementaroInfo/main.rb)*
- `ruby - <<'RB'
attrs_def = {'price_eur'=>10}
attrs_inst = {'price_eur'=>20}
attrs = attrs_def.merge(attrs_inst)
puts attrs['price_eur']
RB`

------
https://chatgpt.com/codex/tasks/task_e_68990e11c6e8832c82be33d0b174e234