### PR TITLE
feat: include selection set in filter key

### DIFF
--- a/ElementaroInfo/ui/app.js
+++ b/ElementaroInfo/ui/app.js
@@ -252,14 +252,16 @@
     }
 
     function filterKey(){
+      const follow = $('#followSel').checked;
+      const selKey = follow ? [...selectedPids].sort().join(',') : '';
       return JSON.stringify({
         q: $('#q').value || '',
         type: $('#fType').value || '',
         tag: $('#fTag').value || '',
         incomplete: $('#fIncomplete').checked,
         onlyPinned: $('#onlyPinned').checked,
-        followSel: $('#followSel').checked,
-        selSize: $('#followSel').checked ? selectedPids.size : 0,
+        followSel: follow,
+        selKey,
         excluded: [...excludedDefs].sort(),
         pinned:   [...pinnedDefs].sort(),
         rowsVer: rowsVersion


### PR DESCRIPTION
## Summary
- incorporate sorted selection set into cache key when following selection

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990e101fcc832cbad873527f501473