### PR TITLE
Optimize definition total price aggregation

### DIFF
--- a/ElementaroInfo/ui/app.js
+++ b/ElementaroInfo/ui/app.js
@@ -311,12 +311,16 @@
       refreshChips();
       const vis = visibleRows();
 
-      const defs=new Set(vis.map(r=>r.definition_name).filter(Boolean));
-      const types=new Set(vis.map(r=>r.entity_kind));
-      const sumPrice = [...defs].reduce((acc,d)=>{
-        const rr = vis.find(x=>x.definition_name===d);
-        return acc + Number(rr?.def_total_price_eur||0);
-      },0);
+      const defs=new Map();
+      const types=new Set();
+      vis.forEach(r=>{
+        types.add(r.entity_kind);
+        const d=r.definition_name;
+        if(d && !defs.has(d)){
+          defs.set(d, Number(r.def_total_price_eur||0));
+        }
+      });
+      const sumPrice=[...defs.values()].reduce((acc,v)=>acc+v,0);
       $('#kpiCount').textContent = `Zeilen: ${vis.length.toLocaleString()}`;
       $('#kpiTypes').textContent = `Entitäten: ${[...types].join(', ')||'-'}`;
       $('#kpiDefs').textContent  = `Definitionen: ${defs.size.toLocaleString()}`;


### PR DESCRIPTION
## Summary
- Iterate visible rows once to build a definition-to-price map.
- Use aggregated map to derive unique definition count and total price metrics.
- Eliminate repeated `vis.find` calls in render logic.

## Testing
- `node --check ElementaroInfo/ui/app.js` *(fails: Invalid or unexpected token)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990e0f55dc832cab43faedbd3c2bc2