### PR TITLE
Add AGENTS guidelines and unit tests with CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - run: ruby -Itest test/test_elementaro_autoinfo.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+## Entwicklungsrichtlinien
+- Verwende Einrückungen mit zwei Leerzeichen in Ruby-Dateien.
+- Führe vor jedem Commit die Tests mit `ruby -Itest test/test_elementaro_autoinfo.rb` aus.
+
+## Tests
+- Testdateien liegen im Verzeichnis `test`.
+- Füge Tests für neue Funktionen hinzu.

--- a/test/stubs/extensions.rb
+++ b/test/stubs/extensions.rb
@@ -1,0 +1,9 @@
+class SketchupExtension
+  attr_reader :name, :path
+  attr_accessor :description, :version, :creator
+
+  def initialize(name, path)
+    @name = name
+    @path = path
+  end
+end

--- a/test/stubs/sketchup.rb
+++ b/test/stubs/sketchup.rb
@@ -1,0 +1,15 @@
+module Sketchup
+  @extensions = []
+
+  def self.register_extension(ext, _load = true)
+    @extensions << ext
+  end
+
+  def self.extensions
+    @extensions
+  end
+
+  def self.clear_extensions
+    @extensions.clear
+  end
+end

--- a/test/test_elementaro_autoinfo.rb
+++ b/test/test_elementaro_autoinfo.rb
@@ -1,0 +1,19 @@
+require 'minitest/autorun'
+$LOAD_PATH.unshift File.expand_path('stubs', __dir__)
+require 'sketchup'
+require 'extensions'
+
+class ElementaroAutoinfoTest < Minitest::Test
+  def setup
+    Sketchup.clear_extensions
+  end
+
+  def test_extension_registration
+    load File.expand_path('../elementaro_autoinfo.rb', __dir__)
+    assert_equal 1, Sketchup.extensions.length
+    ext = Sketchup.extensions.first
+    assert_equal 'Elementaro AutoInfo', ext.name
+    assert_equal '2.3.0', ext.version
+    assert_equal 'Elementaro', ext.creator
+  end
+end


### PR DESCRIPTION
## Summary
- Add repository AGENTS.md with basic development and test instructions
- Introduce Minitest for plugin registration and metadata
- Configure GitHub Actions workflow to run tests automatically

## Testing
- `ruby -Itest test/test_elementaro_autoinfo.rb`


------
https://chatgpt.com/codex/tasks/task_e_6899219f4e1c832ca6128df697d6690a