### PR TITLE
Add UI mock data and scaffold

### DIFF
--- a/ElementaroInfo/ui/main.html
+++ b/ElementaroInfo/ui/main.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Elementaro Info</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body class="layout">
+    <div id="sidebar" class="layout__sidebar"></div>
+    <div id="main-content" class="layout__main-content">
+      <div id="data-table" class="data-table"></div>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/ElementaroInfo/ui/mock_data.json
+++ b/ElementaroInfo/ui/mock_data.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": 1,
+    "name": "Beam A",
+    "type": "Component",
+    "attributes": {
+      "length": 2.5,
+      "material": "Steel",
+      "weight": 12.5
+    }
+  },
+  {
+    "id": 2,
+    "name": "Column B",
+    "type": "Group",
+    "attributes": {
+      "height": 3.0,
+      "material": "Concrete",
+      "reinforced": true
+    }
+  },
+  {
+    "id": 3,
+    "name": "Panel C",
+    "type": "Component",
+    "attributes": {
+      "width": 1.2,
+      "height": 2.4,
+      "material": "Glass"
+    }
+  },
+  {
+    "id": 4,
+    "name": "Bracket D",
+    "type": "Group",
+    "attributes": {
+      "length": 0.5,
+      "material": "Aluminum",
+      "angle": 45
+    }
+  },
+  {
+    "id": 5,
+    "name": "Connector E",
+    "type": "Component",
+    "attributes": {
+      "diameter": 0.1,
+      "material": "Plastic",
+      "color": "Red"
+    }
+  },
+  {
+    "id": 6,
+    "name": "Plate F",
+    "type": "Group",
+    "attributes": {
+      "width": 0.8,
+      "height": 0.8,
+      "thickness": 0.02
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add mock data for UI simulation
- create base HTML structure for UI with sidebar, main content, and data table containers

## Testing
- `ruby -Itest test/test_elementaro_autoinfo.rb`


------
https://chatgpt.com/codex/tasks/task_e_68992a336de8832cba720305637515af