### PR TITLE
chore: add RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+
+Rails:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 20
+
+Style/FrozenStringLiteralComment:
+  Enabled: true


### PR DESCRIPTION
## Summary
- add basic RuboCop config with frozen string literal comment and method length limit

## Testing
- `ruby -Itest test/test_elementaro_autoinfo.rb`


------
https://chatgpt.com/codex/tasks/task_e_68992a44aa98832cbff0921d6b750713