### PR TITLE
Ensure observers detach on dialog close

### DIFF
--- a/ElementaroInfo/main.rb
+++ b/ElementaroInfo/main.rb
@@ -50,6 +50,12 @@
         m.selection.add_observer(@sel_obs) rescue nil
       end
 
+      def detach_observers
+        m = Sketchup.active_model
+        m.remove_observer(@model_obs) rescue nil if @model_obs
+        m.selection.remove_observer(@sel_obs) rescue nil if @sel_obs
+      end
+
       # ---------------- Entry ----------------
       def show_panel
         @dlg&.close
@@ -62,6 +68,7 @@
           scrollable: true, resizable: true, width: 1240, height: 860
         )
         wire_callbacks
+        @dlg.set_on_closed { detach_observers }
 
         # UI aus Datei laden
         ui_root = File.join(__dir__, 'ui')

--- a/test/stubs/sketchup.rb
+++ b/test/stubs/sketchup.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
 module Sketchup
   @extensions = []
 
@@ -12,4 +16,53 @@ module Sketchup
   def self.clear_extensions
     @extensions.clear
   end
+
+  class Model
+    attr_reader :selection, :observers
+
+    def initialize
+      @selection = Selection.new
+      @observers = []
+    end
+
+    def add_observer(obs)
+      @observers << obs
+    end
+
+    def remove_observer(obs)
+      @observers.delete(obs)
+    end
+  end
+
+  class Selection
+    attr_reader :observers
+
+    def initialize
+      @observers = []
+    end
+
+    def add_observer(obs)
+      @observers << obs
+    end
+
+    def remove_observer(obs)
+      @observers.delete(obs)
+    end
+  end
+
+  class ModelObserver; end
+  class SelectionObserver; end
+
+  def self.active_model
+    @active_model ||= Model.new
+  end
+
+  def self.temp_dir
+    Dir.tmpdir
+  end
+
+  def self.reset
+    @active_model = Model.new
+  end
 end
+

--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+
+$LOAD_PATH.unshift File.expand_path('../../test/stubs', __dir__)
+require 'sketchup'
+
+module UI
+  class HtmlDialog
+    def initialize(**_opts)
+      @visible = false
+      @on_closed = nil
+    end
+
+    def add_action_callback(*); end
+    def set_file(_path); end
+    def set_html(_html); end
+
+    def set_on_closed(&block)
+      @on_closed = block
+    end
+
+    def show
+      @visible = true
+    end
+
+    def visible?
+      @visible
+    end
+
+    def execute_script(_script); end
+
+    def close
+      @visible = false
+      @on_closed&.call
+    end
+  end
+
+  class Menu
+    def add_submenu(_name)
+      self
+    end
+    def add_item(_name); end
+  end
+
+  def self.menu(_name)
+    Menu.new
+  end
+end
+require_relative '../../ElementaroInfo/main'
+
+class TestDetachObservers < Minitest::Test
+  def setup
+    Sketchup.reset
+  end
+
+  def test_observers_detached_after_close
+    ElementaroInfo.show_panel
+    model = Sketchup.active_model
+
+    assert_equal 1, model.observers.length
+    assert_equal 1, model.selection.observers.length
+
+    ElementaroInfo.instance_variable_get(:@dlg).close
+
+    assert_empty model.observers
+    assert_empty model.selection.observers
+  end
+end
+


### PR DESCRIPTION
### Zweck
Sichert, dass beim Schließen des Panels alle SketchUp-Observer entfernt werden.

### Änderungen
- `detach_observers` implementiert, um Model- und Selection-Observer abzumelden.
- `UI::HtmlDialog#set_on_closed` nutzt nun die neue Routine.
- Minitest ergänzt, der nach Schließen des Panels auf observer-freies Modell prüft.

### Tests
- `ruby test/test_elementaro_autoinfo.rb`
- `ruby tests/unit/test_scanner.rb`
- `ruby tests/unit/test_detach_observers.rb`
- `rubocop --force-default-config` *(meldet bestehende Style-Warnungen)*

### Risiken & Rollback
- Risiko: Stubs decken nicht alle SketchUp-APIs ab.
- Rollback: Vorherige Version der Erweiterung einspielen.

------
https://chatgpt.com/codex/tasks/task_e_68993bcb79a0832c8c9f87b00da0b883