### PR TITLE
Capture timer id for thumbnail queue

### DIFF
--- a/ElementaroInfo/main.rb
+++ b/ElementaroInfo/main.rb
@@ -234,7 +234,7 @@
         to_js('EA.toast("Starte Thumbnail-Queue …")')
         to_js('EA.thumbProgress(0)')
         batch = 3
-        UI.start_timer(0.03, true) do |timer|
+        timer_id = UI.start_timer(0.03, true) do
           begin
             processed = 0
             while processed < batch && !list.empty?
@@ -249,13 +249,13 @@
             prog = ((done.to_f/total)*100).round
             to_js("EA.thumbProgress(#{prog})")
             if list.empty?
-              timer.stop
+              UI.stop_timer(timer_id)
               send_rows(@cache_rows) # aktualisiere Thumb-URIs
               to_js('EA.thumbsReady()')
             end
           rescue => ex
             warn "[EA] queue timer err: #{ex.message}"
-            timer.stop rescue nil
+            UI.stop_timer(timer_id) rescue nil
             to_js('EA.thumbsReady()')
           end
         end

--- a/tests/stubs/sketchup.rb
+++ b/tests/stubs/sketchup.rb
@@ -1,0 +1,54 @@
+module Sketchup
+  def self.temp_dir
+    Dir.pwd
+  end
+
+  def self.active_model
+    Model.new
+  end
+
+  class Model
+    def definitions
+      {}
+    end
+
+    def selection
+      []
+    end
+
+    def entities
+      []
+    end
+
+    def layers
+      []
+    end
+
+    def add_observer(*); end
+  end
+
+  class ModelObserver; end
+  class SelectionObserver; end
+end
+
+module UI
+  def self.menu(_name)
+    Menu.new
+  end
+
+  class Menu
+    def add_submenu(_name)
+      self
+    end
+
+    def add_item(_name)
+      self
+    end
+  end
+
+  def self.start_timer(*args)
+    1
+  end
+
+  def self.stop_timer(_id); end
+end

--- a/tests/unit/test_queue_thumbs.rb
+++ b/tests/unit/test_queue_thumbs.rb
@@ -1,0 +1,24 @@
+$LOAD_PATH.unshift File.expand_path('../stubs', __dir__)
+require_relative '../test_helper'
+require_relative '../../ElementaroInfo/main'
+
+class TestQueueThumbs < Minitest::Test
+  def test_empty_list_does_not_start_timer
+    start_called = false
+    stop_called = false
+    UI.stub(:start_timer, ->(*args, &block) {
+      start_called = true
+      1
+    }) do
+      UI.stub(:stop_timer, ->(_id) {
+        stop_called = true
+      }) do
+        ElementaroInfo.stub(:to_js, nil) do
+          ElementaroInfo.queue_thumbs([], only_missing: true)
+        end
+      end
+    end
+    assert_equal false, start_called, 'timer should not start for empty list'
+    assert_equal false, stop_called,  'timer should not stop for empty list'
+  end
+end


### PR DESCRIPTION
### Zweck
Sichert das Beenden der Thumbnail-Queue.

### Änderungen
- Speichert Timer-ID von `UI.start_timer` und stoppt über `UI.stop_timer`.
- Test für leere Thumbnail-Queue hinzugefügt.

### Tests
- `rubocop --plugin rubocop-rails ElementaroInfo/main.rb tests/unit/test_queue_thumbs.rb`
- `ruby -Itests -e 'Dir["tests/unit/test_*.rb"].each { |f| require_relative f }'`

### Risiken & Rollback
- Geringes Risiko, Timer wird nicht mehr korrekt gestoppt.
- Rollback: Vorherige Version von `ElementaroInfo/main.rb` wiederherstellen.


------
https://chatgpt.com/codex/tasks/task_e_68993bcc4874832c9a1b68bba75f6ee3