### PR TITLE
refactor: move UI inline styles to CSS classes

### DIFF
--- a/ElementaroInfo/ui/app.js
+++ b/ElementaroInfo/ui/app.js
@@ -104,10 +104,12 @@
           if(!cb) return;
           if(cb.checked) visibleCols.add(k); else visibleCols.delete(k);
         });
-        saveCols(); buildHeader(); render(); menu.style.display='none';
+        saveCols(); buildHeader(); render(); menu.classList.add('is-hidden');
       };
-      menu.style.display='block';
-      document.addEventListener('click', (ev)=>{ if(!menu.contains(ev.target) && ev.target.id!=='btnColumns'){ menu.style.display='none'; }}, {once:true});
+      menu.classList.remove('is-hidden');
+      document.addEventListener('click', (ev)=>{
+        if(!menu.contains(ev.target) && ev.target.id!=='btnColumns') menu.classList.add('is-hidden');
+      }, {once:true});
     };
 
     function saveCols(){
@@ -203,7 +205,7 @@
         x.setAttribute('aria-selected', active? 'true':'false');
         x.setAttribute('tabindex', active? '0':'-1');
         const view=document.getElementById(x.getAttribute('aria-controls'));
-        if(view) view.style.display = active? '' : 'none';
+        if(view) view.classList.toggle('is-hidden', !active);
       });
       if(t.dataset.tab==='catalog') drawCatalog();
     }
@@ -478,7 +480,7 @@
     }
 
     function drawCards(){
-      if($('#cardsView').style.display==='none'){ $('#cards').innerHTML=''; return; }
+      if($('#cardsView').classList.contains('is-hidden')){ $('#cards').innerHTML=''; return; }
       const cards=$('#cards'); cards.innerHTML='';
         const map={}; currentVis.forEach(r=>{ if(!excludedDefs.has(r.definition_name)) map[r.definition_name]=r; });
       Object.values(map).forEach(r=>{
@@ -549,7 +551,7 @@
     }
 
     function drawCatalog(){
-      if($('#catalogView').style.display==='none') return;
+      if($('#catalogView').classList.contains('is-hidden')) return;
       const wrap=$('#catalog'); wrap.innerHTML='';
       if(!defsCatalog || !defsCatalog.length){ wrap.innerHTML='<div class="small muted">Noch keine Daten – „Jetzt scannen“ klicken.</div>'; return; }
       defsCatalog.forEach(d=>{

--- a/ElementaroInfo/ui/index.html
+++ b/ElementaroInfo/ui/index.html
@@ -19,7 +19,7 @@
 
   <div class="ea-bar">
     <input id="q" type="text" placeholder="Suche …" size="40" aria-label="Suche">
-    <label style="margin-left:auto;">Nur Merkliste <input type="checkbox" id="onlyPinned"></label>
+    <label class="ea-bar__only-pinned">Nur Merkliste <input type="checkbox" id="onlyPinned"></label>
     <button id="btnCollapseAll">Alle ▸</button>
     <button id="btnExpandAll">Alle ▾</button>
     <button id="btnThumbsMissing">Thumbs fehlend</button>
@@ -55,8 +55,8 @@
       </div>
       <div class="section">
         <div class="sec-title">Attribute & Anzeige</div>
-        <label>Attribute (CSV):<br><input type="text" id="attrKeys" style="width:100%"></label>
-        <label>Dezimalstellen <input type="number" id="decimals" min="0" max="6" style="width:60px"></label>
+        <label>Attribute (CSV):<br><input type="text" id="attrKeys" class="ea-side__attr-keys"></label>
+        <label>Dezimalstellen <input type="number" id="decimals" min="0" max="6" class="ea-side__decimals"></label>
         <label>Zählweise
           <select id="countMode"><option value="instances">Instanzen</option><option value="definitions">Definitionen</option></select>
         </label>
@@ -88,17 +88,17 @@
         </div>
 
         <!-- CARDS + INSPECTOR -->
-        <div id="cardsView" class="view" style="display:none" role="tabpanel" aria-labelledby="tab-cards">
+        <div id="cardsView" class="view is-hidden" role="tabpanel" aria-labelledby="tab-cards">
           <div id="cards"></div>
           <aside id="inspector">
             <h3>Inspector</h3>
             <div class="small muted">Karte (Definition) oder Instanz wählen, um Attribute zu bearbeiten.</div>
-            <div id="inspBody" class="muted" style="margin-top:10px">Keine Auswahl.</div>
+            <div id="inspBody" class="muted insp-body">Keine Auswahl.</div>
           </aside>
         </div>
 
         <!-- CATALOG: alle Definitionen -->
-        <div id="catalogView" class="view" style="display:none" role="tabpanel" aria-labelledby="tab-catalog">
+        <div id="catalogView" class="view is-hidden" role="tabpanel" aria-labelledby="tab-catalog">
           <div id="catalog"></div>
         </div>
       </div>
@@ -113,14 +113,14 @@
       <div class="ea-tray">
         <h4>Merkliste</h4>
         <div class="list" id="pinTray"></div>
-        <h4 style="margin-top:10px">Ausgeblendet</h4>
+        <h4 class="ea-tray__subtitle">Ausgeblendet</h4>
         <div class="list" id="excludeTray"></div>
       </div>
     </main>
   </div>
 
   <!-- Spaltenmenü -->
-  <div id="colsMenu" class="ea-cols-menu" style="display:none">
+  <div id="colsMenu" class="ea-cols-menu is-hidden">
     <div class="head">Spalten</div>
     <div id="colsBody"></div>
     <div class="foot"><button id="colsClose">OK</button></div>

--- a/ElementaroInfo/ui/styles.css
+++ b/ElementaroInfo/ui/styles.css
@@ -4,13 +4,17 @@ body{font-family:Segoe UI,Arial,sans-serif;margin:0;color:#111827}
 button{padding:6px 10px;border:1px solid #d1d5db;background:#fff;border-radius:6px;cursor:pointer}
 button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 .muted{color:var(--muted)} .small{font-size:12px}
+.is-hidden{display:none}
 
 .ea-header{padding:10px 12px;background:#0f172a;color:#fff;display:flex;gap:12px;align-items:center}
 .ea-header .title{font-weight:600;margin-right:auto}
 .ea-bar{padding:8px 12px;display:flex;gap:10px;align-items:center;border-bottom:1px solid var(--border);flex-wrap:wrap}
+.ea-bar__only-pinned{margin-left:auto}
 .ea-chips{display:flex;gap:6px;align-items:center;flex-wrap:wrap;padding:6px 12px;border-bottom:1px solid var(--border);background:#f3f4f6}
 .ea-panel{display:flex;height:calc(100vh - 232px)}
 .ea-side{width:320px;border-right:1px solid var(--border);display:flex;flex-direction:column}
+.ea-side__attr-keys{width:100%}
+.ea-side__decimals{width:60px}
 .section{padding:12px;border-bottom:1px solid var(--border)} .sec-title{font-weight:600;margin-bottom:6px}
 .ea-main{flex:1;display:flex;flex-direction:column}
 .ea-tabs{display:flex;border-bottom:1px solid var(--border)}
@@ -23,6 +27,7 @@ button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 .ea-kpis{padding:8px 12px;border-top:1px solid var(--border);display:flex;gap:20px;font-size:12px;background:#fafafa}
 .ea-tray{border-top:1px solid var(--border);padding:8px 12px;background:#fafafa}
 .ea-tray .list{display:flex;gap:8px;flex-wrap:wrap}
+.ea-tray__subtitle{margin-top:10px}
 .tagx{display:inline-flex;gap:6px;align-items:center;padding:2px 8px;border:1px solid var(--border);border-radius:999px;background:#fff;font-size:12px}
 .tagx .x{cursor:pointer;color:#ef4444}
 
@@ -45,6 +50,7 @@ tbody tr:hover{background:#f9fafb}
 .card{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff;display:flex;gap:10px;align-items:center;cursor:pointer}
 .card img{width:64px;height:64px;object-fit:contain;border:1px solid var(--border);border-radius:8px}
 #inspector{position:absolute;right:0;top:0;bottom:0;width:360px;border-left:1px solid var(--border);padding:12px;overflow:auto;background:#fcfcfc}
+.insp-body{margin-top:10px}
 #catalog{padding:12px;display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
 .catalog-card{border:1px solid var(--border);border-radius:12px;padding:8px;background:#fff;display:flex;gap:8px;align-items:center}
 .catalog-card img{width:56px;height:56px;object-fit:contain;border:1px solid var(--border);border-radius:8px}


### PR DESCRIPTION
### Zweck
Entfernt Inline-Styles aus dem HtmlDialog-Markup und kapselt Regeln in CSS/JS.

### Änderungen
- Ersetzt alle `style="..."`-Attribute in `index.html` durch semantische Klassen und erweitert `styles.css`.
- Aktualisiert `app.js`, um Sichtbarkeit über CSS-Klassen (`is-hidden`) zu steuern.

### Tests
- `rubocop` *(fails: obsolete Rails config)*
- `npx htmlhint ElementaroInfo/ui/index.html`
- `npx stylelint ElementaroInfo/ui/styles.css` *(fails: No configuration provided)*
- `npx eslint ElementaroInfo/ui/app.js` *(fails: Missing configuration)*
- `ruby tests/unit/test_scanner.rb`
- Manuell: HTML geladen und Tabs/Spaltenmenü auf korrekte Sichtbarkeit geprüft.

### Risiken & Rollback
- **Risiko:** Verhaltensänderungen beim Umschalten der Ansichten oder beim Spaltenmenü.
- **Rollback:** Vorherige Version von `ElementaroInfo/ui` wiederherstellen.


------
https://chatgpt.com/codex/tasks/task_e_68993bce110c832ca37a527064037a97