### PR TITLE
feat: add catalog pdf export

### DIFF
--- a/ElementaroInfoDev/ui/app.js
+++ b/ElementaroInfoDev/ui/app.js
@@ -170,6 +170,7 @@
     $('#btnExportCsv').onclick  = ()=> SUI.exportCsv  && SUI.exportCsv(JSON.stringify(currentVisibleRows()));
     $('#btnExportJson').onclick = ()=> SUI.exportJson && SUI.exportJson(JSON.stringify(currentVisibleRows()));
     $('#btnExportZip').onclick  = ()=> SUI.exportZip  && SUI.exportZip(JSON.stringify(currentVisibleRows()));
+    $('#btnExportCatalogPdf').onclick = ()=> SUI.exportCatalogPdf && SUI.exportCatalogPdf();
 
     $('#btnCollapseAll').onclick = ()=>{ expanded=new Set(); render(); };
     $('#btnExpandAll').onclick   = ()=>{ expanded=new Set(allRows.map(r=>r.path)); render(); };
@@ -558,8 +559,12 @@
         const el=document.createElement('div'); el.className='catalog-card';
         const img=document.createElement('img'); if(d.thumb) img.src=d.thumb;
         const col=document.createElement('div');
+        const price = typeof d.price_eur==='number' ? d.price_eur.toFixed(decimals) : '';
+        const parents = (d.parents||[]).join(' / ');
         col.innerHTML = `<div><strong>${d.definition_name}</strong></div>
-                         <div class="small muted">${Object.keys(d.entity_kinds||{}).join(', ')}</div>
+                         <div class="small">${d.description||''}</div>
+                         <div class="small muted">Preis: ${price}</div>
+                         <div class="small muted">Übergeordnet: ${parents}</div>
                          <div class="small muted">Instanzen: ${d.count_instances}</div>`;
         el.appendChild(img); el.appendChild(col);
         el.onclick=()=> openDefInspector(d.definition_name);

--- a/ElementaroInfoDev/ui/index.html
+++ b/ElementaroInfoDev/ui/index.html
@@ -99,6 +99,7 @@
 
         <!-- CATALOG: alle Definitionen -->
         <div id="catalogView" class="view is-hidden" role="tabpanel" aria-labelledby="tab-catalog">
+          <div class="catalog-actions"><button id="btnExportCatalogPdf">PDF</button></div>
           <div id="catalog"></div>
         </div>
       </div>

--- a/ElementaroInfoDev/ui/styles.css
+++ b/ElementaroInfoDev/ui/styles.css
@@ -54,6 +54,7 @@ tbody tr:hover{background:#f9fafb}
 #catalog{padding:12px;display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
 .catalog-card{border:1px solid var(--border);border-radius:12px;padding:8px;background:#fff;display:flex;gap:8px;align-items:center}
 .catalog-card img{width:56px;height:56px;object-fit:contain;border:1px solid var(--border);border-radius:8px}
+.catalog-actions{padding:12px}
 
 .ea-cols-menu{position:fixed;right:16px;top:64px;width:260px;background:#fff;border:1px solid var(--border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.15);z-index:50}
 .ea-cols-menu .head{padding:8px 10px;border-bottom:1px solid var(--border);font-weight:600}


### PR DESCRIPTION
### Zweck
Katalogeinträge mit Preisen/Beschreibung anzeigen und als PDF exportieren.

### Änderungen
- bereichert Katalogdaten um Beschreibung, Preis und Elternpfade
- ergänzt PDF-Export des Katalogs
- zeigt Zusatzinfos und PDF-Button in der UI

### Tests
- Unit: `ruby -I tests tests/unit/test_scanner.rb`
- UI: `npx --yes htmlhint ElementaroInfoDev/ui/index.html`
- Smoke: _nicht ausgeführt_

### Risiken & Rollback
- Risiko: PDF-Export benötigt vorhandenes `prawn`-Gem
- Rollback: Vorversion RBZ einspielen.

------
https://chatgpt.com/codex/tasks/task_e_689f8f47c3b8832c8d8dc5e12c7116b1