### PR TITLE
Fix outdated module references and cancel scan hook

### DIFF
--- a/ElementaroInfoDev/main.rb
+++ b/ElementaroInfoDev/main.rb
@@ -417,6 +417,11 @@
         end
       end
 
+      def cancel_scan!
+        @cancel_scan = true
+        @scan_timer&.stop
+      end
+
       def scan_with_cache(opts)
         opts = normalize_scan_opts(opts)
         if @cache_rows && @cache_opts == opts && !@model_dirty

--- a/tests/unit/test_async_scan.rb
+++ b/tests/unit/test_async_scan.rb
@@ -148,38 +148,38 @@ class MockEntity < Sketchup::ComponentInstance
   end
 end
 
-require_relative '../../ElementaroInfo/main'
+require_relative '../../ElementaroInfoDev/main'
 
-ElementaroInfo.singleton_class.class_eval do
+ElementaroInfoDev.singleton_class.class_eval do
   attr_accessor :js_calls
 end
 
-ElementaroInfo.define_singleton_method(:to_js) do |js|
+ElementaroInfoDev.define_singleton_method(:to_js) do |js|
   (self.js_calls ||= []) << js
 end
-ElementaroInfo.define_singleton_method(:send_rows) { |_rows| }
-ElementaroInfo.define_singleton_method(:send_defs_summary) { }
+ElementaroInfoDev.define_singleton_method(:send_rows) { |_rows| }
+ElementaroInfoDev.define_singleton_method(:send_defs_summary) { }
 
 class TestAsyncScan < Minitest::Test
   def setup
-    ElementaroInfo.js_calls = []
-    ElementaroInfo.send(:remove_const, :CHUNK_SIZE)
-    ElementaroInfo.const_set(:CHUNK_SIZE, 2)
+    ElementaroInfoDev.js_calls = []
+    ElementaroInfoDev.send(:remove_const, :CHUNK_SIZE)
+    ElementaroInfoDev.const_set(:CHUNK_SIZE, 2)
     ents = (1..5).map { |i| MockEntity.new(i) }
     Sketchup.active_model = Sketchup::Model.new(ents)
   end
 
   def test_progress_and_cancel
-    ElementaroInfo.scan_async(ElementaroInfo.default_opts)
-    progress = ElementaroInfo.js_calls.grep(/EA\.scanProgress\((\d+)\)/)
+    ElementaroInfoDev.scan_async(ElementaroInfoDev.default_opts)
+    progress = ElementaroInfoDev.js_calls.grep(/EA\.scanProgress\((\d+)\)/)
     refute_empty progress
 
-    ElementaroInfo.cancel_scan!
-    timer = ElementaroInfo.instance_variable_get(:@scan_timer)
+    ElementaroInfoDev.cancel_scan!
+    timer = ElementaroInfoDev.instance_variable_get(:@scan_timer)
     timer.trigger
     assert timer.stopped?
 
-    last = ElementaroInfo.js_calls.grep(/EA\.scanProgress\((\d+)\)/).last
+    last = ElementaroInfoDev.js_calls.grep(/EA\.scanProgress\((\d+)\)/).last
     value = last[/\d+/].to_i
     assert value < 100
   end

--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -48,7 +48,7 @@ module UI
     Menu.new
   end
 end
-require_relative '../../ElementaroInfo/main'
+require_relative '../../ElementaroInfoDev/main'
 
 class TestDetachObservers < Minitest::Test
   def setup
@@ -56,13 +56,13 @@ class TestDetachObservers < Minitest::Test
   end
 
   def test_observers_detached_after_close
-    ElementaroInfo.show_panel
+    ElementaroInfoDev.show_panel
     model = Sketchup.active_model
 
     assert_equal 1, model.observers.length
     assert_equal 1, model.selection.observers.length
 
-    ElementaroInfo.instance_variable_get(:@dlg).close
+    ElementaroInfoDev.instance_variable_get(:@dlg).close
 
     assert_empty model.observers
     assert_empty model.selection.observers

--- a/tools/build.rb
+++ b/tools/build.rb
@@ -11,8 +11,8 @@ VERSION = begin
 rescue StandardError
   '0.0.0'
 end
-TARGET  = File.join(DIST, "elementaro_autoinfo-v#{VERSION}.rbz")
-SOURCES = %w[elementaro_autoinfo.rb ElementaroInfo README.md].freeze
+TARGET  = File.join(DIST, "elementaro_autoinfo_dev-v#{VERSION}.rbz")
+SOURCES = %w[elementaro_autoinfo_dev.rb ElementaroInfoDev README.md].freeze
 
 FileUtils.rm_rf(DIST)
 FileUtils.mkdir_p(DIST)


### PR DESCRIPTION
### Summary
- update unit tests to use `ElementaroInfoDev`
- add `cancel_scan!` helper to stop async scanning
- update build script for `elementaro_autoinfo_dev` packaging

### Testing
- `ruby tests/unit/test_async_scan.rb`
- `ruby tests/unit/test_detach_observers.rb`
- `ruby tests/unit/test_scanner.rb`
- `ruby test/test_elementaro_autoinfo_dev.rb`
- `ruby tools/build.rb`
- `rubocop` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f8f7318dc832cbb9fd018eb9addca