### PR TITLE
Ensure observers detach on dialog close

### DIFF
--- a/ElementaroInfoDev/main.rb
+++ b/ElementaroInfoDev/main.rb
@@ -54,8 +54,14 @@
 
       def detach_observers
         m = Sketchup.active_model
-        m.remove_observer(@model_obs) rescue nil if @model_obs
-        m.selection.remove_observer(@sel_obs) rescue nil if @sel_obs
+        if @model_obs
+          m.remove_observer(@model_obs) rescue nil
+          @model_obs = nil
+        end
+        if @sel_obs
+          m.selection.remove_observer(@sel_obs) rescue nil
+          @sel_obs = nil
+        end
       end
 
       # ---------------- Entry ----------------
@@ -70,7 +76,7 @@
           scrollable: true, resizable: true, width: 1240, height: 860
         )
         wire_callbacks
-        @dlg.set_on_closed { detach_observers }
+        @dlg.set_on_closed { ElementaroInfoDev.detach_observers }
 
         # UI aus Datei laden
         ui_root = File.join(__dir__, 'ui')

--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -48,7 +48,7 @@ module UI
     Menu.new
   end
 end
-require_relative '../../ElementaroInfo/main'
+require_relative '../../ElementaroInfoDev/main'
 
 class TestDetachObservers < Minitest::Test
   def setup
@@ -56,13 +56,13 @@ class TestDetachObservers < Minitest::Test
   end
 
   def test_observers_detached_after_close
-    ElementaroInfo.show_panel
+    ElementaroInfoDev.show_panel
     model = Sketchup.active_model
 
     assert_equal 1, model.observers.length
     assert_equal 1, model.selection.observers.length
 
-    ElementaroInfo.instance_variable_get(:@dlg).close
+    ElementaroInfoDev.instance_variable_get(:@dlg).close
 
     assert_empty model.observers
     assert_empty model.selection.observers


### PR DESCRIPTION
### Purpose
Ensure SketchUp observers are properly removed when the dialog closes.

### Changes
- Centralized `detach_observers` to remove model and selection observers.
- Safely invoke `detach_observers` via dialog `set_on_closed`.
- Updated unit test to load `ElementaroInfoDev` and verify observer cleanup.

### Tests
- `rubocop`
- `ruby tests/unit/test_detach_observers.rb`


------
https://chatgpt.com/codex/tasks/task_e_689f9ae74794832c9c57a207813c5826