### PR TITLE
Fix async scan cancellation and update tests

### DIFF
--- a/ElementaroInfoDev/main.rb
+++ b/ElementaroInfoDev/main.rb
@@ -440,6 +440,10 @@
         end
       end
 
+      def cancel_scan!
+        @cancel_scan = true
+      end
+
       def scan_with_cache(opts)
         opts = normalize_scan_opts(opts)
         if @cache_rows && @cache_opts == opts && !@model_dirty

--- a/tests/unit/test_async_scan.rb
+++ b/tests/unit/test_async_scan.rb
@@ -148,38 +148,37 @@ class MockEntity < Sketchup::ComponentInstance
   end
 end
 
-require_relative '../../ElementaroInfo/main'
-
-ElementaroInfo.singleton_class.class_eval do
+require_relative '../../ElementaroInfoDev/main'
+ElementaroInfoDev.singleton_class.class_eval do
   attr_accessor :js_calls
 end
 
-ElementaroInfo.define_singleton_method(:to_js) do |js|
+ElementaroInfoDev.define_singleton_method(:to_js) do |js|
   (self.js_calls ||= []) << js
 end
-ElementaroInfo.define_singleton_method(:send_rows) { |_rows| }
-ElementaroInfo.define_singleton_method(:send_defs_summary) { }
+ElementaroInfoDev.define_singleton_method(:send_rows) { |_rows| }
+ElementaroInfoDev.define_singleton_method(:send_defs_summary) { }
 
 class TestAsyncScan < Minitest::Test
   def setup
-    ElementaroInfo.js_calls = []
-    ElementaroInfo.send(:remove_const, :CHUNK_SIZE)
-    ElementaroInfo.const_set(:CHUNK_SIZE, 2)
+    ElementaroInfoDev.js_calls = []
+    ElementaroInfoDev.send(:remove_const, :CHUNK_SIZE)
+    ElementaroInfoDev.const_set(:CHUNK_SIZE, 2)
     ents = (1..5).map { |i| MockEntity.new(i) }
     Sketchup.active_model = Sketchup::Model.new(ents)
   end
 
   def test_progress_and_cancel
-    ElementaroInfo.scan_async(ElementaroInfo.default_opts)
-    progress = ElementaroInfo.js_calls.grep(/EA\.scanProgress\((\d+)\)/)
+    ElementaroInfoDev.scan_async(ElementaroInfoDev.default_opts)
+    progress = ElementaroInfoDev.js_calls.grep(/EA\.scanProgress\((\d+)\)/)
     refute_empty progress
 
-    ElementaroInfo.cancel_scan!
-    timer = ElementaroInfo.instance_variable_get(:@scan_timer)
+    ElementaroInfoDev.cancel_scan!
+    timer = ElementaroInfoDev.instance_variable_get(:@scan_timer)
     timer.trigger
     assert timer.stopped?
 
-    last = ElementaroInfo.js_calls.grep(/EA\.scanProgress\((\d+)\)/).last
+    last = ElementaroInfoDev.js_calls.grep(/EA\.scanProgress\((\d+)\)/).last
     value = last[/\d+/].to_i
     assert value < 100
   end

--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -48,7 +48,7 @@ module UI
     Menu.new
   end
 end
-require_relative '../../ElementaroInfo/main'
+require_relative '../../ElementaroInfoDev/main'
 
 class TestDetachObservers < Minitest::Test
   def setup
@@ -56,13 +56,13 @@ class TestDetachObservers < Minitest::Test
   end
 
   def test_observers_detached_after_close
-    ElementaroInfo.show_panel
+    ElementaroInfoDev.show_panel
     model = Sketchup.active_model
 
     assert_equal 1, model.observers.length
     assert_equal 1, model.selection.observers.length
 
-    ElementaroInfo.instance_variable_get(:@dlg).close
+    ElementaroInfoDev.instance_variable_get(:@dlg).close
 
     assert_empty model.observers
     assert_empty model.selection.observers


### PR DESCRIPTION
### Zweck
Behebt fehlendes `cancel_scan!` und aktualisiert Tests auf `ElementaroInfoDev`.

### Änderungen
- Methode `cancel_scan!` implementiert.
- Unit-Tests auf `ElementaroInfoDev` umgestellt.

### Tests
- `ruby tests/unit/test_async_scan.rb`
- `ruby tests/unit/test_detach_observers.rb`
- `ruby tests/unit/test_scanner.rb`
- `rubocop` *(schlug fehl: command not found)*

### Risiken & Rollback
- Geringes Risiko, nur Tests und interne API angepasst.
- Rollback: Vorversion wiederherstellen.

------
https://chatgpt.com/codex/tasks/task_e_689f94fbe42c832c9c9c639bfbc8e4e1