### PR TITLE
chore: remove Rails reference from RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,6 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.1
 
-Rails:
-  Enabled: false
-
 Metrics/MethodLength:
   Max: 20
 


### PR DESCRIPTION
### Zweck
Remove obsolete Rails department from RuboCop config to avoid requiring the rubocop-rails gem.

### Änderungen
- drop `Rails` section from `.rubocop.yml` to stop unused dependency lookup

### Tests
- Unit: `ruby test/test_elementaro_autoinfo.rb`, `ruby tests/unit/test_scanner.rb`
- Lint: `rubocop --format simple` *(fails: 387 offenses remain)*
- UI: not run
- Smoke: not run

### Risiken & Rollback
- Risiko: none anticipated
- Rollback: revert `.rubocop.yml` to prior version

------
https://chatgpt.com/codex/tasks/task_e_689f93ed40e0832c870caca7671483b2