### PR TITLE
fix: robust timers and async scan

### DIFF
--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -41,6 +41,7 @@ module UI
     def add_submenu(_name)
       self
     end
+
     def add_item(_name); end
   end
 
@@ -48,7 +49,7 @@ module UI
     Menu.new
   end
 end
-require_relative '../../ElementaroInfo/main'
+require_relative '../../ElementaroInfoDev/main'
 
 class TestDetachObservers < Minitest::Test
   def setup
@@ -56,16 +57,15 @@ class TestDetachObservers < Minitest::Test
   end
 
   def test_observers_detached_after_close
-    ElementaroInfo.show_panel
+    ElementaroInfoDev.show_panel
     model = Sketchup.active_model
 
     assert_equal 1, model.observers.length
     assert_equal 1, model.selection.observers.length
 
-    ElementaroInfo.instance_variable_get(:@dlg).close
+    ElementaroInfoDev.instance_variable_get(:@dlg).close
 
     assert_empty model.observers
     assert_empty model.selection.observers
   end
 end
-

--- a/tests/unit/test_queue_thumbs.rb
+++ b/tests/unit/test_queue_thumbs.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+$LOAD_PATH.unshift File.expand_path('../../test/stubs', __dir__)
+require 'sketchup'
+
+module UI
+  class HtmlDialog; end
+  class Menu
+    def add_submenu(_name); self; end
+    def add_item(_name); 1; end
+  end
+  def self.menu(_name)
+    Menu.new
+  end
+end
+
+require_relative '../../ElementaroInfoDev/main'
+
+# rubocop:disable Style/Documentation
+class TestQueueThumbs < Minitest::Test
+  def setup
+    Sketchup.reset
+    Sketchup.active_model.define_singleton_method(:definitions) { Hash.new(true) }
+    called = false
+    UI.singleton_class.class_eval do
+      define_method(:start_timer) do |_interval, _repeat, &block|
+        block.call
+        :tid
+      end
+      define_method(:stop_timer) do |_id|
+        called = true
+      end
+    end
+    @called_ref = -> { called }
+    ElementaroInfoDev.define_singleton_method(:thumb_path) { |_n| '' }
+    ElementaroInfoDev.define_singleton_method(:ensure_thumb_for) { |_n| nil }
+    ElementaroInfoDev.define_singleton_method(:send_rows) { |_rows| nil }
+    ElementaroInfoDev.define_singleton_method(:to_js) { |_js| nil }
+  end
+
+  def test_timer_stopped
+    ElementaroInfoDev.queue_thumbs(['a'], only_missing: false)
+    assert @called_ref.call, 'expected stop_timer to be called'
+  end
+end
+# rubocop:enable Style/Documentation

--- a/tests/unit/test_scanner.rb
+++ b/tests/unit/test_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require_relative '../../ElementaroInfoDev/lib/scanner'
 


### PR DESCRIPTION
### Zweck
Stabilere Timer-Verwaltung und cancelbarer Modellscan.

### Änderungen
- Abbruchfähigen `scan_async` mit `cancel_scan!` und sauberem `UI.stop_timer`
- Thumbnail-Queue speichert Timer-ID und stoppt Timer korrekt
- Tests für Observer-Detach, asynchronen Scan und Timer-Queue aktualisiert

### Tests
- `rubocop ElementaroInfoDev/main.rb tests/unit/test_async_scan.rb tests/unit/test_detach_observers.rb tests/unit/test_queue_thumbs.rb tests/unit/test_scanner.rb` (offenses remaining)
- `for f in tests/unit/test_*.rb; do echo "Running $f"; ruby -I test/stubs "$f" || break; done`


------
https://chatgpt.com/codex/tasks/task_e_6899352b648c832c90ced75ae37c3a93