### PR TITLE
Capture timer id for thumbnail queue

### DIFF
--- a/tests/stubs/sketchup.rb
+++ b/tests/stubs/sketchup.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/Documentation, Lint/EmptyClass
+module Sketchup
+  def self.temp_dir
+    Dir.pwd
+  end
+
+  def self.active_model
+    Model.new
+  end
+
+  class Model
+    def definitions
+      {}
+    end
+
+    def selection
+      []
+    end
+
+    def entities
+      []
+    end
+
+    def layers
+      []
+    end
+
+    def add_observer(*); end
+  end
+
+  class ModelObserver; end
+  class SelectionObserver; end
+end
+
+module UI
+  def self.menu(_name)
+    Menu.new
+  end
+
+  class Menu
+    def add_submenu(_name)
+      self
+    end
+
+    def add_item(_name)
+      self
+    end
+  end
+
+  def self.start_timer(*)
+    1
+  end
+
+  def self.stop_timer(_id); end
+end
+
+# rubocop:enable Style/Documentation, Lint/EmptyClass

--- a/tests/unit/test_queue_thumbs.rb
+++ b/tests/unit/test_queue_thumbs.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../stubs', __dir__)
+require_relative '../test_helper'
+require_relative '../../ElementaroInfo/main'
+
+# Tests for ElementaroInfo.queue_thumbs
+class TestQueueThumbs < Minitest::Test
+  def test_empty_list_does_not_start_timer
+    start_called = false
+    stop_called = false
+    UI.stub(:start_timer, lambda do |_time, _repeat, &_block|
+      start_called = true
+      1
+    end) do
+      UI.stub(:stop_timer, lambda do |_id|
+        stop_called = true
+      end) do
+        ElementaroInfo.stub(:to_js, nil) do
+          ElementaroInfo.queue_thumbs([], only_missing: true)
+        end
+      end
+    end
+    assert_equal false, start_called, 'timer should not start for empty list'
+    assert_equal false, stop_called,  'timer should not stop for empty list'
+  end
+end


### PR DESCRIPTION
### Zweck
Sichert das Beenden der Thumbnail-Queue.

### Änderungen
- Speichert Timer-ID von `UI.start_timer` und stoppt über `UI.stop_timer`.
- Test für leere Thumbnail-Queue hinzugefügt.
- Style-Anpassungen für Tests, Stubs und Modulabschluss.

### Tests
- `rubocop --plugin rubocop-rails ElementaroInfo/main.rb tests/unit/test_queue_thumbs.rb tests/stubs/sketchup.rb` *(bestehende Offenses in `ElementaroInfo/main.rb`)*
- `ruby -Itests -e 'Dir["tests/unit/test_*.rb"].each { |f| require_relative f }'`

### Risiken & Rollback
- Geringes Risiko, Timer wird nicht mehr korrekt gestoppt.
- Rollback: Vorherige Version von `ElementaroInfo/main.rb` wiederherstellen.


------
https://chatgpt.com/codex/tasks/task_e_68993bcc4874832c9a1b68bba75f6ee3