### PR TITLE
chore(ci): add automerge workflow for codex

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,18 @@
+name: Enable Auto Merge for Codex
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable:
+    if: github.actor == 'codex-bot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          merge-method: squash


### PR DESCRIPTION
### Zweck
Automatisches Mergen von Codex-PRs nach erfolgreicher CI.

### Änderungen
- GitHub-Action, die PRs des Users `codex-bot` für Auto-Merge markiert.

### Tests
- Unit: `ruby -Itest test/test_elementaro_autoinfo_dev.rb`
- Lint: `rubocop` *(fehlte; Installation schlug fehl)*
- UI: _nicht ausgeführt_
- Smoke: _nicht ausgeführt_

### Risiken & Rollback
- Risiko: Falscher Actor-Name verhindert Auto-Merge oder aktiviert ihn unerwartet.
- Rollback: `.github/workflows/automerge.yml` entfernen.

------
https://chatgpt.com/codex/tasks/task_e_689fa48fa160832ca02cb75faf56a86a