### PR TITLE
chore: add RuboCop auto-fix helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rubocop', require: false

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # SketchupEventPlugins
 SketchupPlugins für Eventmanagement, Lieferanten, Baupläne etc Mangement
+
+## Entwicklung
+
+RuboCop-Autokorrektur ausführen:
+
+```bash
+bundle exec ruby tools/auto_fix.rb
+```

--- a/tools/auto_fix.rb
+++ b/tools/auto_fix.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+system('rubocop', '-A') || abort('RuboCop auto-correction failed')


### PR DESCRIPTION
### Zweck
RuboCop-Autokorrektur erleichtern

### Änderungen
- `Gemfile` mit RuboCop-Entwicklungsabhängigkeit
- Skript `tools/auto_fix.rb` zum Ausführen von `rubocop -A`
- README beschreibt Auto-Fix-Aufruf

### Tests
- `ruby -Itests tests/unit/test_async_scan.rb`
- `ruby -Itests tests/unit/test_detach_observers.rb`
- `ruby -Itests tests/unit/test_scanner.rb`
- `rubocop` (erwartete Verstöße)

### Risiken & Rollback
- Geringes Risiko, da nur Dev-Tools.
- Rollback: commit zurücksetzen.


------
https://chatgpt.com/codex/tasks/task_e_689fa5510ae4832c9959a25668acc982