### PR TITLE
chore: add frozen string literal comments

### DIFF
--- a/test/stubs/sketchup.rb
+++ b/test/stubs/sketchup.rb
@@ -65,4 +65,3 @@ module Sketchup
     @active_model = Model.new
   end
 end
-

--- a/test/test_elementaro_autoinfo_dev.rb
+++ b/test/test_elementaro_autoinfo_dev.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 $LOAD_PATH.unshift File.expand_path('stubs', __dir__)
 require 'sketchup'

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../ElementaroInfoDev', __dir__)
 
 require 'minitest/autorun'

--- a/tests/unit/test_async_scan.rb
+++ b/tests/unit/test_async_scan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'tmpdir'
 require 'ostruct'
@@ -15,6 +17,7 @@ module UI
 
     def trigger
       return if @stopped
+
       @block.call(self)
       @stopped = true unless @repeat
     end
@@ -49,19 +52,21 @@ module UI
   end
 
   class HtmlDialog
-    def initialize(*) ; end
-    def add_action_callback(*) ; end
-    def set_file(*) ; end
-    def set_html(*) ; end
-    def show ; end
-    def execute_script(*) ; end
+    # rubocop:disable Style/SingleLineMethods
+    def initialize(*); end
+    def add_action_callback(*); end
+    def set_file(*); end
+    def set_html(*); end
+    def show; end
+    def execute_script(*); end
     def visible?; false; end
     def close; end
+    # rubocop:enable Style/SingleLineMethods
   end
 end
 
 module Geom
-  Z_AXIS = [0, 0, 1]
+  Z_AXIS = [0, 0, 1].freeze
 end
 
 module Sketchup
@@ -157,8 +162,8 @@ end
 ElementaroInfo.define_singleton_method(:to_js) do |js|
   (self.js_calls ||= []) << js
 end
-ElementaroInfo.define_singleton_method(:send_rows) { |_rows| }
-ElementaroInfo.define_singleton_method(:send_defs_summary) { }
+ElementaroInfo.define_singleton_method(:send_rows) { |_rows| nil }
+ElementaroInfo.define_singleton_method(:send_defs_summary) { |_summary| nil }
 
 class TestAsyncScan < Minitest::Test
   def setup

--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -14,8 +14,11 @@ module UI
     end
 
     def add_action_callback(*); end
+
+    # rubocop:disable Naming/AccessorMethodName
     def set_file(_path); end
     def set_html(_html); end
+    # rubocop:enable Naming/AccessorMethodName
 
     def set_on_closed(&block)
       @on_closed = block
@@ -41,6 +44,7 @@ module UI
     def add_submenu(_name)
       self
     end
+
     def add_item(_name); end
   end
 
@@ -68,4 +72,3 @@ class TestDetachObservers < Minitest::Test
     assert_empty model.selection.observers
   end
 end
-

--- a/tests/unit/test_scanner.rb
+++ b/tests/unit/test_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require_relative '../../ElementaroInfoDev/lib/scanner'
 


### PR DESCRIPTION
## Summary
- add missing `# frozen_string_literal: true` comments in test files
- tidy up test stubs and guard clauses for RuboCop

## Testing
- `rubocop`
- `ruby test/test_elementaro_autoinfo_dev.rb`
- `ruby tests/unit/test_scanner.rb`
- `ruby tests/unit/test_async_scan.rb` *(fails: cannot load such file -- /workspace/SketchupEventPlugins/ElementaroInfo/main)*
- `ruby tests/unit/test_detach_observers.rb` *(fails: cannot load such file -- /workspace/SketchupEventPlugins/ElementaroInfo/main)*


------
https://chatgpt.com/codex/tasks/task_e_689f94fbe42c832c9c9c639bfbc8e4e1