### PR TITLE
chore(test): silence RuboCop in observer test

### DIFF
--- a/tests/unit/test_detach_observers.rb
+++ b/tests/unit/test_detach_observers.rb
@@ -6,16 +6,18 @@ require 'tmpdir'
 $LOAD_PATH.unshift File.expand_path('../../test/stubs', __dir__)
 require 'sketchup'
 
-module UI
-  class HtmlDialog
+module UI # :nodoc:
+  class HtmlDialog # :nodoc:
     def initialize(**_opts)
       @visible = false
       @on_closed = nil
     end
 
     def add_action_callback(*); end
+    # rubocop:disable Naming/AccessorMethodName
     def set_file(_path); end
     def set_html(_html); end
+    # rubocop:enable Naming/AccessorMethodName
 
     def set_on_closed(&block)
       @on_closed = block
@@ -37,10 +39,11 @@ module UI
     end
   end
 
-  class Menu
+  class Menu # :nodoc:
     def add_submenu(_name)
       self
     end
+
     def add_item(_name); end
   end
 
@@ -50,6 +53,7 @@ module UI
 end
 require_relative '../../ElementaroInfoDev/main'
 
+# Tests that observers are detached once the panel closes.
 class TestDetachObservers < Minitest::Test
   def setup
     Sketchup.reset
@@ -68,4 +72,3 @@ class TestDetachObservers < Minitest::Test
     assert_empty model.selection.observers
   end
 end
-


### PR DESCRIPTION
### Zweck
Silence RuboCop warnings in observer detachment test.

### Änderungen
- mark UI stub classes with `# :nodoc:`
- disable `Naming/AccessorMethodName` for API-like stubs
- document `TestDetachObservers`

### Tests
- `rubocop tests/unit/test_detach_observers.rb`
- `ruby -Itests tests/unit/test_detach_observers.rb`
- `rubocop` *(fails: 446 offenses remain project-wide)*

### Risiken & Rollback
- minimal; revert commit if issues arise.

------
https://chatgpt.com/codex/tasks/task_e_689fab0ea110832caa1109fe0589220b