### PR TITLE
fix: correct test file path for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
-      - run: ruby -Itest test/test_elementaro_autoinfo_dev.rb
+          ruby-version: '3.2'
+      - run: ruby -Itest test/test_elementaro_autoinfo.rb
       - run: ruby -Itests tests/unit/test_scanner.rb && ruby -Itests tests/unit/test_exporter.rb

--- a/test/test_elementaro_autoinfo.rb
+++ b/test/test_elementaro_autoinfo.rb
@@ -1,15 +1,20 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
-$LOAD_PATH.unshift File.expand_path('stubs', __dir__)
-require 'sketchup'
-require 'extensions'
+require_relative 'stubs/sketchup'
+require_relative 'stubs/extensions'
 
 class ElementaroAutoinfoDevTest < Minitest::Test
+  STUB_DIR = File.expand_path('stubs', __dir__)
+
   def setup
     Sketchup.clear_extensions
   end
 
   def test_extension_registration
+    $LOAD_PATH.unshift STUB_DIR
     load File.expand_path('../elementaro_autoinfo_dev.rb', __dir__)
+    $LOAD_PATH.delete(STUB_DIR)
     assert_equal 1, Sketchup.extensions.length
     ext = Sketchup.extensions.first
     assert_equal 'Elementaro AutoInfo Dev', ext.name


### PR DESCRIPTION
### Zweck
Sichert, dass der Extension-Test stabil in der CI läuft.

### Änderungen
- Test `test/test_elementaro_autoinfo.rb` isoliert Stub-Load-Path.
- CI-Workflow nutzt Ruby 3.2 und ruft den neuen Testpfad auf.

### Tests
- `ruby -Itest test/test_elementaro_autoinfo.rb`
- `ruby -Itests tests/unit/test_scanner.rb`
- `ruby -Itests tests/unit/test_exporter.rb`
- `rubocop test/test_elementaro_autoinfo.rb`


------
https://chatgpt.com/codex/tasks/task_e_689fbd5d3000832ca6190be8dd8788f4