### PR TITLE
chore(ci): allow codex user for automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   enable:
-    if: github.actor == 'codex-bot'
+    # Allow auto-merge for both the codex-bot automation and the codex user
+    if: github.actor == 'codex-bot' || github.actor == 'codex'
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v2


### PR DESCRIPTION
## Summary
- allow codex user to trigger the automerge workflow

## Testing
- `rubocop`
- `ruby tests/unit/test_*.rb`


------
https://chatgpt.com/codex/tasks/task_e_689fc3933480832caf5572f018d21941