### PR TITLE
fix(scanner): prevent cycles during traversal

### DIFF
--- a/tests/unit/test_scanner.rb
+++ b/tests/unit/test_scanner.rb
@@ -87,5 +87,17 @@ class TestScanner < Minitest::Test
     child_attrs = results.last[:attributes]['info']
     assert_equal 1, child_attrs['val']
   end
+
+  def test_scan_avoids_cycles
+    a = MockEntity.new('A')
+    b = MockEntity.new('B')
+    a.definition.entities.instance_variable_set(:@list, [b])
+    b.definition.entities.instance_variable_set(:@list, [a])
+    model = MockModel.new([a])
+
+    results = @scanner.scan_model(model)
+    names = results.map { |r| r[:entity].definition.name }
+    assert_equal %w[A B], names
+  end
 end
 # rubocop:enable Style/Documentation


### PR DESCRIPTION
### Zweck
Verhindert Endlosschleifen beim Traversieren von Entity-Bäumen.

### Änderungen
- Zykluserkennung in `EntityTraverser` mittels `Set` implementiert.
- Unit-Test ergänzt, der zyklische Referenzen abdeckt.

### Tests
- `ruby -I tests tests/unit/test_scanner.rb`
- `ruby -I tests tests/unit/test_exporter.rb`
- `ruby -I tests tests/unit/test_queue_thumbs.rb`
- `ruby -I tests tests/unit/test_async_scan.rb`
- `ruby -I tests tests/unit/test_detach_observers.rb`
- `ruby -I test test/test_elementaro_autoinfo.rb`

### Risiken & Rollback
- Gering: Traverser nutzt jetzt zusätzliche `Set`-Struktur; bei Problemen Vorversion einspielen.


------
https://chatgpt.com/codex/tasks/task_e_689fe22431d4832ca4a3d121640e3a3c