### PR TITLE
feat(excel): add Excel sync module

### DIFF
--- a/ElementaroInfoDev/lib/excel_sync.rb
+++ b/ElementaroInfoDev/lib/excel_sync.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rubyXL'
+
+module ElementaroInfoDev
+  # ExcelSync handles export and import of attribute data
+  # to and from Excel (XLSX) files. Export takes scanner
+  # results, import reads a workbook into a hash structure,
+  # and apply writes imported attributes back to entities.
+  class ExcelSync
+    HEADER = %w[EntityID Dictionary Key Value].freeze
+
+    # Exports scanner results to an XLSX file.
+    # @param results [Array<Hash>] data from Scanner#scan_model
+    # @param path [String] destination path for the xlsx file
+    # rubocop:disable Metrics/AbcSize
+    def export(results, path)
+      workbook = RubyXL::Workbook.new
+      worksheet = workbook[0]
+      HEADER.each_with_index { |h, i| worksheet.add_cell(0, i, h) }
+
+      row = 1
+      results.each do |entry|
+        entity_id = entry[:entity].object_id
+        entry[:attributes].each do |dict_name, attrs|
+          attrs.each do |key, value|
+            worksheet.add_cell(row, 0, entity_id)
+            worksheet.add_cell(row, 1, dict_name)
+            worksheet.add_cell(row, 2, key)
+            worksheet.add_cell(row, 3, value)
+            row += 1
+          end
+        end
+      end
+      workbook.write(path)
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    # Imports an XLSX file and returns attribute data.
+    # @param path [String] source xlsx file path
+    # @return [Hash{Integer=>Hash}]
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def import(path)
+      workbook = RubyXL::Parser.parse(path)
+      worksheet = workbook[0]
+      data = {}
+      worksheet.each_with_index do |row, idx|
+        next if idx.zero?
+
+        eid = row[0]&.value
+        dict = row[1]&.value
+        key = row[2]&.value
+        value = row[3]&.value
+        next if eid.nil? || dict.nil? || key.nil?
+
+        eid = eid.to_i
+        data[eid] ||= {}
+        data[eid][dict] ||= {}
+        data[eid][dict][key] = value
+      end
+      data
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    # Applies imported attribute data to entities in the model.
+    # @param model [Object] model responding to `entities`
+    # @param data [Hash] data from {#import}
+    def apply(model, data)
+      entities_by_id = model.entities.to_h { |e| [e.object_id, e] }
+      data.each do |eid, dicts|
+        entity = entities_by_id[eid]
+        next unless entity
+
+        dicts.each do |dict_name, attrs|
+          attrs.each do |key, value|
+            entity.set_attribute(dict_name, key, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/tests/unit/test_excel_sync.rb
+++ b/tests/unit/test_excel_sync.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'tmpdir'
+require 'rubyXL'
+require_relative '../../ElementaroInfoDev/lib/scanner'
+require_relative '../../ElementaroInfoDev/lib/excel_sync'
+
+# Minimal dictionary stub to emulate SketchUp attribute dictionaries
+class StubDictionary < Hash
+  attr_reader :name
+
+  def initialize(name, attrs = {})
+    super()
+    @name = name
+    attrs.each { |k, v| self[k.to_s] = v }
+  end
+
+  def each_pair(&)
+    each(&)
+  end
+end
+
+# Simple entity stub with attribute dictionary support
+class StubEntity
+  def initialize(dicts = {})
+    @dicts = dicts.map { |name, attrs| StubDictionary.new(name, attrs) }
+  end
+
+  def attribute_dictionaries
+    @dicts
+  end
+
+  def set_attribute(dict_name, key, value)
+    dictionary = @dicts.find { |d| d.name == dict_name }
+    unless dictionary
+      dictionary = StubDictionary.new(dict_name)
+      @dicts << dictionary
+    end
+    dictionary.store(key.to_s, value)
+  end
+
+  def get_attribute(dict_name, key)
+    dictionary = @dicts.find { |d| d.name == dict_name }
+    dictionary&.[](key.to_s)
+  end
+end
+
+# Simple model wrapper providing entities collection
+class StubModel
+  attr_reader :entities
+
+  def initialize(entities)
+    @entities = entities
+  end
+end
+
+# Tests for ElementaroInfoDev::ExcelSync
+class ExcelSyncTest < Minitest::Test
+  def setup
+    @entity = StubEntity.new('elementaro' => { 'foo' => '1' })
+    @model = StubModel.new([@entity])
+    @scanner = ElementaroInfoDev::Scanner.new
+    @excel = ElementaroInfoDev::ExcelSync.new
+  end
+
+  def test_export_import_and_apply
+    results = @scanner.scan_model(@model)
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'sync.xlsx')
+      @excel.export(results, path)
+
+      wb = RubyXL::Parser.parse(path)
+      sheet = wb[0]
+      sheet[1][3].raw_value = '2'
+      wb.write(path)
+
+      data = @excel.import(path)
+      @excel.apply(@model, data)
+
+      assert_equal '2', @entity.get_attribute('elementaro', 'foo')
+    end
+  end
+end


### PR DESCRIPTION
### Zweck
Excel-Attribute können jetzt per XLSX exportiert, bearbeitet und zurück ins Modell synchronisiert werden.

### Änderungen
- neues `ExcelSync`-Modul zum Export/Import und Anwenden von Attributen
- Unit-Test für Export→Excel→Import→Anwendung

### Tests
- `rubocop ElementaroInfoDev/lib/excel_sync.rb tests/unit/test_excel_sync.rb`
- `ruby test/test_elementaro_autoinfo.rb`
- `ruby tests/unit/test_excel_sync.rb`

### Risiken & Rollback
- benötigt das `rubyXL`-Gem in der Zielumgebung
- Rollback: Commit rückgängig machen

------
https://chatgpt.com/codex/tasks/task_e_68a0b9eeeb40832cb68b533d09881ab7